### PR TITLE
ADD normalized passport structure

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,24 @@ function TAccountsStrategy(options, verify) {
         return callback(new Error('Invalid response status: ' + response.statusCode));
       }
 
-      return callback(null, body);
+      // see normalized profile http://passportjs.org/docs/profile
+      var normalizedProfile = {
+        provider: 'taccounts',
+        id: body.userId,
+        displayName: body.profile.fullname
+      };
+
+      normalizedProfile.emails = body.identities.emails.map(function(email) {
+        return {
+          value: email.address,
+          primary: email.main
+        };
+      });
+
+      // original payload for those who need additional fields from Telefonica Accounts
+      normalizedProfile.payload = body;
+
+      return callback(null, normalizedProfile);
     });
   }
 }

--- a/test/unit/taccounts-test.js
+++ b/test/unit/taccounts-test.js
@@ -7,6 +7,31 @@ var events = require('events'),
     OAuth2Strategy = require('passport-oauth2'),
     TAccountsStrategy = require('../../lib');
 
+var TACCOUNTS_PROFILE = {
+  "profile": {
+    "language_pages": true,
+    "fullname": " Andrés Iniesta",
+    "language_code": "es"
+  },
+  "lastUpdateTime": "2015-11-09T19:27:36.100Z",
+  "userId": "e2a1e7c5-9a9b-40b4-b24d-1a7925ba7b92",
+  "creationTime": "2015-09-18T09:06:53.724Z",
+  "accountStatus": 1,
+  "hasPassword": true,
+  "identities": {
+    "emails": [
+      {
+        "verified": true,
+        "verificationTime": "2015-09-18T09:08:14.324Z",
+        "url": "https://accounts.tid.es/telefonica/validate/email",
+        "creationTime": "2015-09-18T09:06:53.724Z",
+        "address": "andres@iniesta.com",
+        "main": true
+      }
+    ]
+  }
+};
+
 describe('TAccounts basic tests', function() {
   it('should create a TAccounts object', function(done) {
     expect(TAccountsStrategy.prototype instanceof OAuth2Strategy).to.be.true;
@@ -46,7 +71,7 @@ describe('TAccounts basic tests', function() {
 });
 
 describe('TAccounts user profile', function() {
-  it('should request the user profile', function(done) {
+  it('should normalize the user profile', function(done) {
     var options = {
       clientID: '2b8672be-5c80-ac91-96da-f4b922105431',
       clientSecret: 'f5d689ac-fc2c-4e32-ac8a-321212ca1a8d'
@@ -55,12 +80,15 @@ describe('TAccounts user profile', function() {
 
     var strategy = new TAccountsStrategy(options, verify);
 
-    var fakeProfile = {foo: 'bar'};
+    var fakeProfile = TACCOUNTS_PROFILE;
     nock(options.profileURL).get('').reply(200, fakeProfile);
 
     strategy.userProfile('faketoken', function(err, profile) {
       expect(err).to.not.exist;
-      expect(profile).to.be.deep.equal(fakeProfile);
+      expect(profile.displayName).to.be.deep.equal(fakeProfile.profile.fullname);
+      expect(profile.id).to.be.deep.equal(fakeProfile.userId);
+      expect(profile.emails[0].value).to.be.deep.equal(fakeProfile.identities.emails[0].address);
+      expect(profile.payload).to.be.deep.equal(fakeProfile);
       done();
     });
   });


### PR DESCRIPTION
Fixes #7 (see discussion there) to return a user using the normalized structure proposed by passport.

Breaks backwards compatibility. Must go to 1.0.0.
