### PR TITLE
[[FEAT]] Add logout support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ are running your own TAccounts service:
 * profileURL
 * authorizeParams: supports prompt='login'
 
+### Logout from Telefónica Accounts
+
+The strategy exposes a new method `logout` as an addition to the common passportJS ones. Use this method to create a middleware that logouts the user directly from 
+Telefónica Accounts and redirects back to the specified `logoutCallbackURL` 
+
+```js
+
+var options = {
+   // Other options
+  logoutCallbackURL: 'http://localhost/auth/logout'
+};
+
+var strategy = new TAccountsStrategy(options, verify);
+
+passport.use(strategy);
+
+app.get('/auth/taccounts/', passport.authenticate('taccounts'));
+app.get('/auth/taccounts/callback', passport.authenticate('taccounts'));
+app.get('/auth/taccounts/logout', strategy.logout());
+
+app.get('/auth/logout', function(req, res) {
+  // Gets redirected here after logging out from Telefónica Accounts
+  req.logout();
+  res.redirect('/');
+});
+```
+
+
 ## License
 
 Copyright 2015 [Telefónica Investigación y Desarrollo, S.A.U](http://www.tid.es)

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,6 +73,7 @@ function TAccountsStrategy(options, verify) {
   options.authorizationURL = options.authorizationURL || 'https://accounts.telefonica.com/telefonica/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://accounts.telefonica.com/telefonica/oauth/token';
   options.profileURL = options.profileURL || 'https://accounts.telefonica.com/api/v1/telefonica/users/me';
+  options.logoutURL = options.logoutURL || 'https://accounts.telefonica.com/telefonica/logout';
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'taccounts';
@@ -83,7 +84,19 @@ function TAccountsStrategy(options, verify) {
 
   this.authorizationParams = getAuthorizationParams;
 
+  this.logout = logout;
+
   ///////////////////
+
+  function logout() {
+    if (!options.logoutCallbackURL) {
+      throw new TypeError('TAccountsStrategy requires a logoutCallbackURL option');
+    }
+
+    return function logoutMW(req, res) {
+      res.redirect(options.logoutURL + '?post_logout_redirect_uri=' + options.logoutCallbackURL);
+    };
+  }
 
   function getAuthorizationParams() {
     return options.authorizeParams ? options.authorizeParams : {};

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
   "devDependencies": {
     "chai": "^3.0.0",
     "coveralls": "^2.11.2",
+    "eslint": "^0.23.0",
+    "express": "^4.14.0",
     "istanbul": "^0.3.16",
+    "jscs": "^1.13.1",
     "mocha": "^2.2.5",
     "nock": "^2.13.0",
     "proxyquire": "^1.5.0",
     "should": "^7.0.1",
     "sinon": "~1.15.3",
     "sinon-chai": "^2.8.0",
-    "supertest": "^1.0.1",
-    "xunit-file": "^0.0.6",
-    "jscs": "^1.13.1",
-    "eslint": "^0.23.0"
+    "supertest": "^2.0.0",
+    "xunit-file": "^0.0.6"
   },
   "dependencies": {
     "passport-oauth2": "^1.1.2",


### PR DESCRIPTION
Exposes a new method in the strategy to redirect to the Telefonica Accounts logout endpoint

Closes #15 
