### PR TITLE
migrate to standard OIDC userinfo scopes and endpoit

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,39 +34,20 @@ The original payload is also returned for those who need additional information 
 
 ```json
 {
-    "provider": "taccounts",
-    "id": "e2a1e7c5-9a9b-40b4-b24d-1a7925ba7b92",
-    "displayName": "Andrés Iniesta",
-    "emails": [
-        {
-            "value": "andres@iniesta.com",
-            "primary": true
-        }
-    ],
-    "payload": {
-        "profile": {
-            "language_pages": true,
-            "fullname": " Andrés Iniesta",
-            "language_code": "es"
-        },
-        "lastUpdateTime": "2015-11-09T19:27:36.100Z",
-        "userId": "e2a1e7c5-9a9b-40b4-b24d-1a7925ba7b92",
-        "creationTime": "2015-09-18T09:06:53.724Z",
-        "accountStatus": 1,
-        "hasPassword": true,
-        "identities": {
-            "emails": [
-                {
-                    "verified": true,
-                    "verificationTime": "2015-09-18T09:08:14.324Z",
-                    "url": "https://accounts.tid.es/telefonica/validate/email",
-                    "creationTime": "2015-09-18T09:06:53.724Z",
-                    "address": "andres@iniesta.com",
-                    "main": true
-                }
-            ]
-        }
-    }
+  "email": "frodo.bolson@telefonica.com",
+  "local_company_alias": "HI_frodo",
+  "company": "Telefónica S.A.",
+  "tags": [
+      "ldap_auth",
+      "telefonica_user"
+  ],
+  "sub": "9d2ccf1f-746d-4455-9793-44e1bc8caaa6",
+  "locale": "es",
+  "email_verified": true,
+  "updated_at": "2016-10-25T10:28:35.289Z",
+  "name": "FRODO BOLSON",
+  "phone_number": "+34666666666",
+  "phone_number_verified": true
 }
 ```
 
@@ -81,8 +62,8 @@ are running your own TAccounts service:
 
 ### Logout from Telefónica Accounts
 
-The strategy exposes a new method `logout` as an addition to the common passportJS ones. Use this method to create a middleware that logouts the user directly from 
-Telefónica Accounts and redirects back to the specified `logoutCallbackURL` 
+The strategy exposes a new method `logout` as an addition to the common passportJS ones. Use this method to create a middleware that logouts the user directly from
+Telefónica Accounts and redirects back to the specified `logoutCallbackURL`
 
 ```js
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,11 +59,10 @@ function TAccountsStrategy(options, verify) {
   options = options || {};
 
   options.scope = options.scope || [
-        'accounts.user.read',
-        'accounts.user.read.emails',
-        'accounts.user.read.phones',
-        'accounts.user.read.services',
-        'accounts.user.read.profile'
+        'openid',
+        'profile',
+        'phone',
+        'email'
       ];
 
   options.customHeaders = {
@@ -72,7 +71,7 @@ function TAccountsStrategy(options, verify) {
 
   options.authorizationURL = options.authorizationURL || 'https://accounts.telefonica.com/telefonica/oauth/authorize';
   options.tokenURL = options.tokenURL || 'https://accounts.telefonica.com/telefonica/oauth/token';
-  options.profileURL = options.profileURL || 'https://accounts.telefonica.com/api/v1/telefonica/users/me';
+  options.profileURL = options.profileURL || 'https://accounts.telefonica.com/telefonica/openid/userinfo';
   options.logoutURL = options.logoutURL || 'https://accounts.telefonica.com/telefonica/logout';
 
   OAuth2Strategy.call(this, options, verify);
@@ -122,17 +121,11 @@ function TAccountsStrategy(options, verify) {
       // see normalized profile http://passportjs.org/docs/profile
       var normalizedProfile = {
         provider: 'taccounts',
-        id: body.userId,
-        displayName: body.profile.fullname
+        id: body.sub,
+        displayName: body.name
       };
 
-      normalizedProfile.emails = body.identities.emails.map(function(email) {
-        return {
-          value: email.address,
-          primary: email.main
-        };
-      });
-
+      normalizedProfile.emails = [{value: body.email}];
       // original payload for those who need additional fields from Telefonica Accounts
       normalizedProfile.payload = body;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "passport-taccounts-oauth2",
   "description": "Passport strategy for authenticating with Telefonica Accounts OAuth 2.0 API",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "license": "Apache-2.0",
   "author": {
     "name": "Guido García Bernardo",

--- a/test/unit/taccounts-test.js
+++ b/test/unit/taccounts-test.js
@@ -10,28 +10,20 @@ var events = require('events'),
     TAccountsStrategy = require('../../lib');
 
 var TACCOUNTS_PROFILE = {
-  "profile": {
-    "language_pages": true,
-    "fullname": " Andrés Iniesta",
-    "language_code": "es"
-  },
-  "lastUpdateTime": "2015-11-09T19:27:36.100Z",
-  "userId": "e2a1e7c5-9a9b-40b4-b24d-1a7925ba7b92",
-  "creationTime": "2015-09-18T09:06:53.724Z",
-  "accountStatus": 1,
-  "hasPassword": true,
-  "identities": {
-    "emails": [
-      {
-        "verified": true,
-        "verificationTime": "2015-09-18T09:08:14.324Z",
-        "url": "https://accounts.tid.es/telefonica/validate/email",
-        "creationTime": "2015-09-18T09:06:53.724Z",
-        "address": "andres@iniesta.com",
-        "main": true
-      }
-    ]
-  }
+  "email": "frodo.bolson@telefonica.com",
+  "local_company_alias": "HI_frodo",
+  "company": "Telefónica S.A.",
+  "tags": [
+      "ldap_auth",
+      "telefonica_user"
+  ],
+  "sub": "9d2ccf1f-746d-4455-9793-44e1bc8caaa6",
+  "locale": "es",
+  "email_verified": true,
+  "updated_at": "2016-10-25T10:28:35.289Z",
+  "name": "FRODO BOLSON",
+  "phone_number": "+34666666666",
+  "phone_number_verified": true
 };
 
 describe('TAccounts basic tests', function() {
@@ -88,9 +80,9 @@ describe('TAccounts user profile', function() {
 
     strategy.userProfile('faketoken', function(err, profile) {
       expect(err).to.not.exist;
-      expect(profile.displayName).to.be.deep.equal(fakeProfile.profile.fullname);
-      expect(profile.id).to.be.deep.equal(fakeProfile.userId);
-      expect(profile.emails[0].value).to.be.deep.equal(fakeProfile.identities.emails[0].address);
+      expect(profile.displayName).to.be.deep.equal(fakeProfile.name);
+      expect(profile.id).to.be.deep.equal(fakeProfile.sub);
+      expect(profile.emails[0].value).to.be.deep.equal(fakeProfile.email);
       expect(profile.payload).to.be.deep.equal(fakeProfile);
       done();
     });


### PR DESCRIPTION
when normalizing the payload as specified by passport, type is not specified because no information in received in this regard from TAccounts.

@jmendiara 